### PR TITLE
Don't display ads to dead-ringer players

### DIFF
--- a/addons/sourcemod/scripting/motdgd_adverts.sp
+++ b/addons/sourcemod/scripting/motdgd_adverts.sp
@@ -399,8 +399,13 @@ public Action:Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroa
 {
 	if(!g_eCvars[g_cvarDeathAds][aCache])
 		return Plugin_Continue;
+	
+	CreateTimer(0.0, Timer_HandleDeath, GetEventInt(event, "userid"));
+}
 
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+public Action:Timer_HandleDeath(Handle:timer, any:userid) {
+	new client = GetClientOfUserId(userid);
+	
 	if(client && IsClientInGame(client) && !IsPlayerAlive(client))
 		Helper_RequestAd(client);
 

--- a/addons/sourcemod/scripting/motdgd_adverts.sp
+++ b/addons/sourcemod/scripting/motdgd_adverts.sp
@@ -401,7 +401,7 @@ public Action:Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroa
 		return Plugin_Continue;
 
 	new client = GetClientOfUserId(GetEventInt(event, "userid"));
-	if(client && IsClientInGame(client))
+	if(client && IsClientInGame(client) && !IsPlayerAlive(client))
 		Helper_RequestAd(client);
 
 	return Plugin_Continue;


### PR DESCRIPTION
Ads are displayed to players who feign a death with the Dead Ringer, since player_death is fired on that occasion.
